### PR TITLE
convert to ovos-plugin-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-### mycroft-tts-plugin-azure
+### ovos-tts-plugin-azure
 
-This TTS service for Mycroft requires a subscription to Microsoft Azure and the creation of a Speech resource (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/overview#create-the-azure-resource)
+This TTS service for OpenVoiceOS requires a subscription to Microsoft Azure and the creation of a Speech resource (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/overview#create-the-azure-resource)
 
 The free plan is more than able to handle domestic usage (5 million character per month, or 0.5 million with neural tts).
 You can choose your voice here in the column "voice name" (https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support#text-to-speech)
@@ -9,8 +9,8 @@ Configuration parameters (only the api_key is mandatory, other are defaulted as 
 
 ```json
 "tts": {
-    "module": "azure_tts",
-    "azure_tts": {
+    "module": "ovos-tts-plugin-azure",
+    "ovos-tts-plugin-azure": {
         "api_key": "insert_your_key_here",
         "voice": "en-US-JennyNeural",  # optional, default "en-US-Guy24kRUS"
         "region": "westus" # optional, if your region is westus
@@ -20,7 +20,7 @@ Configuration parameters (only the api_key is mandatory, other are defaulted as 
 
 ##### Installation
 
-`mycroft-pip install mycroft-tts-plugin-azure`
+`pip install ovos-tts-plugin-azure`
 
 ##### LICENSE :
 

--- a/ovos_tts_plugin_azure/__init__.py
+++ b/ovos_tts_plugin_azure/__init__.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 #
 
-from mycroft.tts import TTS, TTSValidator
-from mycroft.util.log import LOG
-
 from datetime import datetime, timedelta
-from mycroft.configuration import Configuration
-import requests
 from xml.etree import ElementTree
+
+import requests
+from ovos_plugin_manager.templates.tts import TTS, TTSValidator
+from ovos_utils.log import LOG
 
 
 class AzureTTSPlugin(TTS):
@@ -38,13 +37,14 @@ class AzureTTSPlugin(TTS):
     The TTS endpoint requires an access token. This method exchanges your
     subscription key for an access token that is valid for ten minutes.
     '''
+
     def renew_token(self):
         now = datetime.now()
-        if self.last_renew and\
+        if self.last_renew and \
                 now - timedelta(minutes=9) <= self.last_renew <= now:
             return
 
-        constructed_url = "https://" + self.region +\
+        constructed_url = "https://" + self.region + \
                           ".api.cognitive.microsoft.com/sts/v1.0/issueToken"
         headers = {
             'Ocp-Apim-Subscription-Key': self.api_key
@@ -55,13 +55,13 @@ class AzureTTSPlugin(TTS):
 
     def get_tts(self, sentence, wav_file):
         self.renew_token()
-        constructed_url = "https://" + self.region +\
+        constructed_url = "https://" + self.region + \
                           ".tts.speech.microsoft.com/cognitiveservices/v1"
         headers = {
             'Authorization': 'Bearer ' + self.access_token,
             'Content-Type': 'application/ssml+xml',
             'X-Microsoft-OutputFormat': 'riff-24khz-16bit-mono-pcm',
-            'User-Agent': 'mycroft'
+            'User-Agent': 'ovos-plugin-manager'
         }
         xml_body = ElementTree.Element('speak', version='1.0')
         xml_body.set('{http://www.w3.org/XML/1998/namespace}lang', 'en-us')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ovos-plugin-manager
+requests

--- a/setup.py
+++ b/setup.py
@@ -9,18 +9,18 @@ HERE = pathlib.Path(__file__).parent
 # The text of the README file
 README = (HERE / "README.md").read_text()
 
-PLUGIN_ENTRY_POINT = 'azure_tts = mycroft_tts_plugin_azure:AzureTTSPlugin'
+PLUGIN_ENTRY_POINT = 'ovos-tts-plugin-azure = ovos_tts_plugin_azure:AzureTTSPlugin'
 setup(
-    name='mycroft-tts-plugin-azure',
+    name='ovos-tts-plugin-azure',
     version='0.1',
-    description='A tts plugin for mycroft, using Azure Cognitive Services',
+    description='A tts plugin for OpenVoiceOS, using Azure Cognitive Services',
     long_description=README,
     long_description_content_type="text/markdown",
-    url='http://github.com/dalgwen/mycroft-tts-plugin-azure',
+    url='http://github.com/dalgwen/ovos-tts-plugin-azure',
     author='Gwendal Roulleau',
     author_email='private@private.org',
     license='Apache-2.0',
-    packages=['mycroft_tts_plugin_azure'],
+    packages=['ovos_tts_plugin_azure'],
     zip_safe=True,
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Hello!

In case you haven't heard Mycroft development moved to OpenVoiceOS, more info here https://community.mycroft.ai/t/faq-ovos-neon-and-the-future-of-the-mycroft-voice-assistant/

this PR updates the plugin for latest best practices, it allows it to be used standalone and still work in existing classic mycroft installs